### PR TITLE
create deployment and initialization scripts, and adjust contracts accordingly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# private key for the executor of the scripts (account must be funded)
+DEPLOYER_PRIVATE_KEY=0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6 # TODO: change this
+# address of the account that will have admin rights over the proxies
+ADDRESS_PROXY_ADMIN=0xa0Ee7A142d267C1f36714E4a8F75612F20a79720 # TODO: change this
+
+# bridge and token address
+ADDRESS_LXLY_BRIDGE=0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe # NOTE: same address for both L1/L2 when eth/zkevm
+ADDRESS_L1_USDC=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 # NOTE: Ethereum Mainnet's USDC
+ADDRESS_L2_USDC=0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512 # TODO: set this after deploying USDC to Polygon ZKEVM
+ADDRESS_L2_WUSDC=0xA8CE8aee21bC2A48a5EF670afCc9274C7bbbC035 # NOTE: Polygon ZKEVM's WrappedUSDC
+
+# these must be set after the deployment and before the initialization
+ADDRESS_L1_ESCROW_PROXY=0xeD1DB453C3156Ff3155a97AD217b3087D5Dc5f6E # TODO: change this
+ADDRESS_ZK_MINTER_BURNER_PROXY=0x8ce361602B935680E8DeC218b820ff5056BeB7af # TODO: change this
+ADDRESS_NATIVE_CONVERTER_PROXY=0xb19b36b1456E65E3A6D514D3F715f204BD59f431 # TODO: change this
+
+# these are internal ids, no need to change
+# https://github.com/0xPolygonHermez/zkevm-contracts/blob/main/contracts/PolygonZkEVMBridge.sol#L38-L42
+L1_CHAIN_ID=0 # 0 for Ethereum mainnet
+L2_CHAIN_ID=1 # 1 for Polygon ZKEVM

--- a/README.md
+++ b/README.md
@@ -27,3 +27,60 @@
 - User converts BridgeWrappedUSDC to USDC.e
   - User calls convert() on NativeConverter, BridgeWrappedUSDC is transferred to NativeConverter. NativeConverter calls mint() on NativeUSDC which mints new supply to the correct address.
   - Anyone can call migrate() on NativeConverter to have all BridgeWrappedUSDC withdrawn via the zkEVMBridge moving the L1_USDC held in the zkEVMBridge to L1Escrow.
+
+## Testing
+
+TBD
+
+## Deployment
+
+First, copy `.env.example` to `.env` and set the appropriate environment variables
+
+### Deployment to Mainnet Forks
+
+Note:
+
+- using 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 as the admin for USDC-E
+- using 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720 as the admin+owner for LXLY contracts
+
+```bash
+# 1 start anvil (doesn't seem to like env vars)
+
+## 1.1 start L1 (ethereum mainnet) anvil
+## NOTE: using port 8001 for L1
+anvil --fork-url <https://eth-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_KEY> --chain-id 1 --port 8001 --fork-block-number 17785773
+
+## 1.2 start L2 (polygon zkevm) anvil
+## NOTE: using port 8101 for L2
+anvil --fork-url <https://polygonzkevm-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_KEY> --chain-id 1101 --port 8101 --fork-block-number 3172683
+
+# 2. deploy and initialize usdc-e to L2
+cd usdc-e/
+forge script script/DeployInit.s.sol:DeployInitUSDC --rpc-url http://localhost:8101 --broadcast -vvvv --legacy
+
+# 3. copy the output address
+FiatTokenV2_1@0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
+
+# 4. and paste into usdc-lxly/.env
+ADDRESS_L2_USDC=0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
+
+# 5. deploy and initialize usdc-lxly
+cd usdc-lxly/
+
+## 5.1 deployment
+forge script scripts/1Deploy.s.sol:DeployL1Contracts --rpc-url http://localhost:8001 --broadcast -vvvv
+forge script scripts/1Deploy.s.sol:DeployL2Contracts --rpc-url http://localhost:8101 --broadcast -vvvv --legacy
+
+## 5.2 copy the output addresses to the .env
+ADDRESS_L1_ESCROW_PROXY=0xeD1DB453C3156Ff3155a97AD217b3087D5Dc5f6E
+ADDRESS_ZK_MINTER_BURNER_PROXY=0x8ce361602B935680E8DeC218b820ff5056BeB7af
+ADDRESS_NATIVE_CONVERTER_PROXY=0xb19b36b1456E65E3A6D514D3F715f204BD59f431
+
+## 5.3 initialization
+forge script scripts/2Init.s.sol:InitL1Contracts --rpc-url http://localhost:8001 --broadcast -vvvv
+forge script scripts/2Init.s.sol:InitL2Contracts --rpc-url http://localhost:8101 --broadcast -vvvv --legacy
+
+# 6. give minter permissions
+cd usdc-e/
+forge script script/AddMinters.s.sol:AddMinters --rpc-url http://localhost:8101 --broadcast -vvvv --legacy
+```

--- a/scripts/1Deploy.s.sol
+++ b/scripts/1Deploy.s.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "lib/forge-std/src/console.sol";
+import "lib/forge-std/src/Script.sol";
+
+import "../src/L1EscrowProxy.sol";
+import "../src/L1EscrowImpl.sol";
+import "../src/NativeConverterProxy.sol";
+import "../src/NativeConverterImpl.sol";
+import "../src/ZkMinterBurnerProxy.sol";
+import "../src/ZkMinterBurnerImpl.sol";
+
+// This script (only) DEPLOYS the L1Escrow contract to L1
+contract DeployL1Contracts is Script {
+    function run() external {
+        vm.startBroadcast(vm.envUint("DEPLOYER_PRIVATE_KEY"));
+
+        // deploy implementation
+        L1EscrowImpl l1eImpl = new L1EscrowImpl();
+        // deploy proxy
+        L1EscrowProxy l1eProxy = new L1EscrowProxy(
+            vm.envAddress("ADDRESS_PROXY_ADMIN"),
+            address(l1eImpl),
+            ""
+        );
+
+        console.log("deployment successful!");
+
+        console.log("ADDRESS_L1_ESCROW_PROXY=%s", address(l1eProxy));
+        console.log("L1EscrowImpl", address(l1eImpl));
+        vm.stopBroadcast();
+    }
+}
+
+// This script (only) DEPLOYS the ZkMinterBurner and NativeConverter contracts to L2
+contract DeployL2Contracts is Script {
+    function run() external {
+        vm.startBroadcast(vm.envUint("DEPLOYER_PRIVATE_KEY"));
+
+        // deploy L2 implementations
+        NativeConverterImpl ncImpl = new NativeConverterImpl();
+        ZkMinterBurnerImpl mbImpl = new ZkMinterBurnerImpl();
+
+        // deploy L2 proxies
+        NativeConverterProxy ncProxy = new NativeConverterProxy(
+            vm.envAddress("ADDRESS_PROXY_ADMIN"),
+            address(ncImpl),
+            ""
+        );
+        ZkMinterBurnerProxy mbProxy = new ZkMinterBurnerProxy(
+            vm.envAddress("ADDRESS_PROXY_ADMIN"),
+            address(mbImpl),
+            ""
+        );
+
+        console.log("deployment successful!");
+
+        console.log("ADDRESS_ZK_MINTER_BURNER_PROXY=%s", address(mbProxy));
+        console.log("ZkMinterBurnerImpl", address(mbImpl));
+
+        console.log("ADDRESS_NATIVE_CONVERTER_PROXY=%s", address(ncProxy));
+        console.log("NativeConverterImpl", address(ncImpl));
+
+        vm.stopBroadcast();
+    }
+}

--- a/scripts/2Init.s.sol
+++ b/scripts/2Init.s.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "lib/forge-std/src/console.sol";
+import "lib/forge-std/src/Script.sol";
+
+import "../src/L1EscrowImpl.sol";
+import "../src/NativeConverterImpl.sol";
+import "../src/ZkMinterBurnerImpl.sol";
+
+contract InitL1Contracts is Script {
+    function run() external {
+        vm.startBroadcast(vm.envUint("DEPLOYER_PRIVATE_KEY"));
+
+        // NOTE: we're just using the interface definition of the impl to fool the compiler
+        L1EscrowImpl l1eProxy = L1EscrowImpl(
+            payable(vm.envAddress("ADDRESS_L1_ESCROW_PROXY"))
+        );
+
+        // initialize the l1 escrow contract through the proxy
+        l1eProxy.initialize(
+            vm.envAddress("ADDRESS_LXLY_BRIDGE"),
+            uint32(vm.envUint("L2_CHAIN_ID")),
+            vm.envAddress("ADDRESS_ZK_MINTER_BURNER_PROXY"),
+            vm.envAddress("ADDRESS_L1_USDC")
+        );
+
+        vm.stopBroadcast();
+    }
+}
+
+contract InitL2Contracts is Script {
+    function run() external {
+        address lxlyBridge = vm.envAddress("ADDRESS_LXLY_BRIDGE");
+        address zkUsdc = vm.envAddress("ADDRESS_L2_USDC"); // ATTN: needs to be deployed beforehand zkUsdc
+        address zkWrappedUsdc = vm.envAddress("ADDRESS_L2_WUSDC");
+        uint32 polygonChainId = uint32(vm.envUint("L1_CHAIN_ID"));
+        address l1Escrow = vm.envAddress("ADDRESS_L1_ESCROW_PROXY");
+
+        vm.startBroadcast(vm.envUint("DEPLOYER_PRIVATE_KEY"));
+
+        // NOTE: we're just using the interface definition of the impl to fool the compiler
+        ZkMinterBurnerImpl zkmbProxy = ZkMinterBurnerImpl(
+            payable(vm.envAddress("ADDRESS_ZK_MINTER_BURNER_PROXY"))
+        );
+        // initialize the minter burner
+        zkmbProxy.initialize(lxlyBridge, polygonChainId, l1Escrow, zkUsdc);
+
+        // NOTE: we're just using the interface definition of the impl to fool the compiler
+        NativeConverterImpl ncProxy = NativeConverterImpl(
+            payable(vm.envAddress("ADDRESS_NATIVE_CONVERTER_PROXY"))
+        );
+        // initialize the native converter
+        ncProxy.initialize(
+            lxlyBridge,
+            polygonChainId,
+            l1Escrow,
+            zkUsdc,
+            zkWrappedUsdc
+        );
+
+        vm.stopBroadcast();
+    }
+}

--- a/src/L1EscrowImpl.sol
+++ b/src/L1EscrowImpl.sol
@@ -27,8 +27,12 @@ contract L1EscrowImpl is Ownable, Pausable, UUPSUpgradeable {
         uint32 zkChainId_,
         address zkContract_,
         address l1Usdc_
-    ) external onlyOwner {
+    ) external onlyProxy {
+        require(msg.sender == _getAdmin(), "NOT_ADMIN");
+
         // TODO: use OZ's Initializable or add if(!initialized)
+        _transferOwnership(msg.sender); // TODO: arg from initialize
+
         bridge = IPolygonZkEVMBridge(bridge_);
         zkChainId = zkChainId_;
         zkContract = zkContract_;

--- a/src/L1EscrowProxy.sol
+++ b/src/L1EscrowProxy.sol
@@ -5,7 +5,10 @@ import "@oz/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract L1EscrowProxy is ERC1967Proxy {
     constructor(
-        address impl,
-        bytes memory data
-    ) payable ERC1967Proxy(impl, data) {}
+        address owner_,
+        address impl_,
+        bytes memory data_
+    ) payable ERC1967Proxy(impl_, data_) {
+        _changeAdmin(owner_);
+    }
 }

--- a/src/NativeConverterImpl.sol
+++ b/src/NativeConverterImpl.sol
@@ -33,8 +33,12 @@ contract NativeConverterImpl is Ownable, Pausable, UUPSUpgradeable {
         address l1Escrow_,
         address zkUSDCe_,
         address zkBWUSDC_
-    ) external onlyOwner {
+    ) external onlyProxy {
+        require(msg.sender == _getAdmin(), "NOT_ADMIN");
+
         // TODO: use OZ's Initializable or add if(!initialized)
+        _transferOwnership(msg.sender); // TODO: arg from initialize
+
         bridge = IPolygonZkEVMBridge(bridge_);
         l1ChainId = l1ChainId_;
         l1Escrow = l1Escrow_;

--- a/src/NativeConverterProxy.sol
+++ b/src/NativeConverterProxy.sol
@@ -5,7 +5,10 @@ import "@oz/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract NativeConverterProxy is ERC1967Proxy {
     constructor(
+        address owner_,
         address impl,
         bytes memory data
-    ) payable ERC1967Proxy(impl, data) {}
+    ) payable ERC1967Proxy(impl, data) {
+        _changeAdmin(owner_);
+    }
 }

--- a/src/ZkMinterBurnerImpl.sol
+++ b/src/ZkMinterBurnerImpl.sol
@@ -33,8 +33,12 @@ contract ZkMinterBurnerImpl is Ownable, Pausable, UUPSUpgradeable {
         uint32 l1ChainId_,
         address l1Contract_,
         address zkUsdc_
-    ) external onlyOwner {
+    ) external onlyProxy {
+        require(msg.sender == _getAdmin(), "NOT_ADMIN");
+
         // TODO: use OZ's Initializable or add if(!initialized)
+        _transferOwnership(msg.sender); // TODO: arg from initialize
+
         bridge = IPolygonZkEVMBridge(bridge_);
         l1ChainId = l1ChainId_;
         l1Contract = l1Contract_;

--- a/src/ZkMinterBurnerProxy.sol
+++ b/src/ZkMinterBurnerProxy.sol
@@ -5,7 +5,10 @@ import "@oz/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract ZkMinterBurnerProxy is ERC1967Proxy {
     constructor(
+        address owner_,
         address impl,
         bytes memory data
-    ) payable ERC1967Proxy(impl, data) {}
+    ) payable ERC1967Proxy(impl, data) {
+        _changeAdmin(owner_);
+    }
 }


### PR DESCRIPTION
deployment happens to 2 different chains (l1 and l2), thus the deployment is broken into 2 different scripts

initialization is a separate step from deployment because contracts have a circular dependency (l1 requires l2 addresses, and l2 requires l1 address)

additionally,
the proxy sets an admin in the constructor
the implementation's initialization is onlyProxy to make sure it's run only through the proxy, and only the proxy's admin is allowed to call it