### PR TITLE
align variable names across the L1EscrowImpl, ZkMinterBurnerImpl, and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-[USDC LxLy](https://docs.google.com/document/d/1heUd3Cbux-ngnCJITbKJ9pdsz26BmNz1hfOn9NTuDH8/edit?pli=1)
+[USDC.E LxLy](https://docs.google.com/document/d/1heUd3Cbux-ngnCJITbKJ9pdsz26BmNz1hfOn9NTuDH8/edit?pli=1)
 
 ## Contracts
 
@@ -19,14 +19,14 @@
 ## Flows
 
 - User Bridges from L1 to zkEVM (post upgrade to USDC.e)
-  - User calls deposit() on L1Escrow, L1_USDC transferred to L1Escrow, message sent to zkEVMBridge targeted to zkEVM’s BridgeMinter.
+  - User calls deposit() on L1Escrow, L1_USDC transferred to L1Escrow, message sent to PolygonZkEVMBridge targeted to zkEVM’s BridgeMinter.
   - Message claimed and sent to BridgeMinter, which calls mint() on NativeUSDC which mints new supply to the correct address.
 - User Bridges from zkEVM to L1 (post upgrade to USDC.e)
-  - User calls withdraw() on BridgeBurner which calls burn() on NativeUSDC burning the supply. Message is sent to zkEVMBridge targeted to L1Escrow.
+  - User calls withdraw() on BridgeBurner which calls burn() on NativeUSDC burning the supply. Message is sent to PolygonZkEVMBridge targeted to L1Escrow.
   - Message claimed and sent to L1Escrow, which transfers L1_USDC to the correct address.
 - User converts BridgeWrappedUSDC to USDC.e
   - User calls convert() on NativeConverter, BridgeWrappedUSDC is transferred to NativeConverter. NativeConverter calls mint() on NativeUSDC which mints new supply to the correct address.
-  - Anyone can call migrate() on NativeConverter to have all BridgeWrappedUSDC withdrawn via the zkEVMBridge moving the L1_USDC held in the zkEVMBridge to L1Escrow.
+  - Anyone can call migrate() on NativeConverter to have all BridgeWrappedUSDC withdrawn via the PolygonZkEVMBridge moving the L1_USDC held in the PolygonZkEVMBridge to L1Escrow.
 
 ## Testing
 

--- a/scripts/DeployInit.s.sol
+++ b/scripts/DeployInit.s.sol
@@ -22,10 +22,12 @@ contract DeployInit is Script {
     uint32 l2NetworkId = uint32(vm.envUint("L2_NETWORK_ID"));
 
     address l1Usdc = vm.envAddress("ADDRESS_L1_USDC");
-    address l2Usdc = vm.envAddress("ADDRESS_L2_USDC"); // ATTN: needs to be deployed beforehand zkUsdc
-    address l2WrappedUsdc = vm.envAddress("ADDRESS_L2_WUSDC");
+    address zkUSDCe = vm.envAddress("ADDRESS_L2_USDC"); // ATTN: needs to be deployed beforehand zkUsdc
+    address zkBWUSDC = vm.envAddress("ADDRESS_L2_WUSDC");
 
+    /// @notice the address that is able to upgrade the proxy contract's implementation contract
     address admin = vm.envAddress("ADDRESS_PROXY_ADMIN");
+    /// @notice the address that is able to pause and unpause the l1Escrow, zkMinterBurner, and nativeConverter contracts
     address owner = vm.envAddress("ADDRESS_OWNER");
 
     function run() external {
@@ -70,8 +72,8 @@ contract DeployInit is Script {
                 l1EscrowProxy,
                 minterBurnerProxy,
                 nativeConverterProxy,
-                l2Usdc,
-                l2WrappedUsdc
+                zkUSDCe,
+                zkBWUSDC
             );
         vm.stopBroadcast();
 

--- a/scripts/DeployInitHelpers.sol
+++ b/scripts/DeployInitHelpers.sol
@@ -79,8 +79,8 @@ library LibDeployInit {
         address l1EscrowProxy,
         address minterBurnerProxy,
         address nativeConverterProxy,
-        address l2Usdc,
-        address l2Wusdc
+        address zkUSDCe,
+        address zkBWUSDC
     )
         internal
         returns (
@@ -95,7 +95,7 @@ library LibDeployInit {
             bridge,
             l1NetworkId,
             l1EscrowProxy,
-            l2Usdc
+            zkUSDCe
         );
 
         // get a reference to the proxy, with the impl's abi, and then call initialize
@@ -105,8 +105,8 @@ library LibDeployInit {
             bridge,
             l1NetworkId,
             l1EscrowProxy,
-            l2Usdc,
-            l2Wusdc
+            zkUSDCe,
+            zkBWUSDC
         );
     }
 }

--- a/src/NativeConverterImpl.sol
+++ b/src/NativeConverterImpl.sol
@@ -20,10 +20,13 @@ contract NativeConverterImpl is CommonAdminOwner {
     event Convert(address indexed from, address indexed to, uint256 amount);
     event Migrate(uint256 amount);
 
+    /// @notice the PolygonZkEVMBridge deployed on the zkEVM
     IPolygonZkEVMBridge public bridge;
     uint32 public l1NetworkId;
     address public l1Escrow;
+    /// @notice The L2 USDC-e deployed on the zkEVM
     IUSDC public zkUSDCe;
+    /// @notice The default L2 USDC TokenWrapped token deployed on the zkEVM
     IUSDC public zkBWUSDC;
 
     constructor() {
@@ -82,8 +85,8 @@ contract NativeConverterImpl is CommonAdminOwner {
 
     function migrate() external whenNotPaused {
         // Anyone can call migrate() on NativeConverter to
-        // have all BridgeWrappedUSDC withdrawn via the zkEVMBridge
-        // moving the L1_USDC held in the zkEVMBridge to L1Escrow
+        // have all zkBridgeWrappedUSDC withdrawn via the PolygonZkEVMBridge
+        // moving the L1_USDC held in the PolygonZkEVMBridge to L1Escrow
 
         uint256 amount = zkBWUSDC.balanceOf(address(this));
 


### PR DESCRIPTION
… NativeConverterImpl.

Prior to this commit, we were using different variables (like l2USDC and zkUSDCE) to refer to the same address. This commit is a refactor that aligns the variable names across the 3 contracts.