### PR TITLE
remove 'Impl' suffix from LxLy contract filenames.

### DIFF
--- a/scripts/DeployInit.s.sol
+++ b/scripts/DeployInit.s.sol
@@ -7,11 +7,11 @@ import "lib/forge-std/src/Script.sol";
 import {LibDeployInit} from "./DeployInitHelpers.sol";
 
 import "../src/L1EscrowProxy.sol";
-import "../src/L1EscrowImpl.sol";
+import "../src/L1Escrow.sol";
 import "../src/NativeConverterProxy.sol";
-import "../src/NativeConverterImpl.sol";
+import "../src/NativeConverter.sol";
 import "../src/ZkMinterBurnerProxy.sol";
-import "../src/ZkMinterBurnerImpl.sol";
+import "../src/ZkMinterBurner.sol";
 
 contract DeployInit is Script {
     uint256 l1ForkId = vm.createFork(vm.envString("L1_RPC_URL"));
@@ -49,7 +49,7 @@ contract DeployInit is Script {
         // init L1 contract
         vm.selectFork(l1ForkId);
         vm.startBroadcast(vm.envUint("DEPLOYER_PRIVATE_KEY"));
-        L1EscrowImpl l1Escrow = LibDeployInit.initL1Contracts(
+        L1Escrow l1Escrow = LibDeployInit.initL1Contracts(
             owner,
             admin,
             l2NetworkId,
@@ -64,8 +64,8 @@ contract DeployInit is Script {
         vm.selectFork(l2ForkId);
         vm.startBroadcast(vm.envUint("DEPLOYER_PRIVATE_KEY"));
         (
-            ZkMinterBurnerImpl minterBurner,
-            NativeConverterImpl nativeConverter
+            ZkMinterBurner minterBurner,
+            NativeConverter nativeConverter
         ) = LibDeployInit.initL2Contracts(
                 owner,
                 admin,

--- a/scripts/DeployInitHelpers.sol
+++ b/scripts/DeployInitHelpers.sol
@@ -4,21 +4,18 @@ pragma solidity ^0.8.17;
 import {CommonBase} from "lib/forge-std/src/Base.sol";
 
 import "../src/L1EscrowProxy.sol";
-import "../src/L1EscrowImpl.sol";
+import "../src/L1Escrow.sol";
 import "../src/NativeConverterProxy.sol";
-import "../src/NativeConverterImpl.sol";
+import "../src/NativeConverter.sol";
 import "../src/ZkMinterBurnerProxy.sol";
-import "../src/ZkMinterBurnerImpl.sol";
+import "../src/ZkMinterBurner.sol";
 
 library LibDeployInit {
     function deployL1Contracts() internal returns (address l1eProxy) {
         // deploy implementation
-        L1EscrowImpl l1EscrowImpl = new L1EscrowImpl();
+        L1Escrow l1Escrow = new L1Escrow();
         // deploy proxy
-        L1EscrowProxy l1EscrowProxy = new L1EscrowProxy(
-            address(l1EscrowImpl),
-            ""
-        );
+        L1EscrowProxy l1EscrowProxy = new L1EscrowProxy(address(l1Escrow), "");
 
         // return address of the proxy
         l1eProxy = address(l1EscrowProxy);
@@ -29,7 +26,7 @@ library LibDeployInit {
         returns (address mbProxy, address ncProxy)
     {
         // deploy implementation
-        ZkMinterBurnerImpl minterBurnerImpl = new ZkMinterBurnerImpl();
+        ZkMinterBurner minterBurnerImpl = new ZkMinterBurner();
         // deploy proxy
         ZkMinterBurnerProxy minterBurnerProxy = new ZkMinterBurnerProxy(
             address(minterBurnerImpl),
@@ -37,10 +34,10 @@ library LibDeployInit {
         );
 
         // deploy implementation
-        NativeConverterImpl nativeConverterImpl = new NativeConverterImpl();
+        NativeConverter nativeConverter = new NativeConverter();
         // deploy proxy
         NativeConverterProxy nativeConverterProxy = new NativeConverterProxy(
-            address(nativeConverterImpl),
+            address(nativeConverter),
             ""
         );
 
@@ -57,9 +54,9 @@ library LibDeployInit {
         address l1EscrowProxy,
         address minterBurnerProxy,
         address l1Usdc
-    ) internal returns (L1EscrowImpl l1Escrow) {
+    ) internal returns (L1Escrow l1Escrow) {
         // get a reference to the proxy, with the impl's abi, and then call initialize
-        l1Escrow = L1EscrowImpl(l1EscrowProxy);
+        l1Escrow = L1Escrow(l1EscrowProxy);
         l1Escrow.initialize(
             owner,
             admin,
@@ -82,13 +79,10 @@ library LibDeployInit {
         address zkBWUSDC
     )
         internal
-        returns (
-            ZkMinterBurnerImpl minterBurner,
-            NativeConverterImpl nativeConverter
-        )
+        returns (ZkMinterBurner minterBurner, NativeConverter nativeConverter)
     {
         // get a reference to the proxy, with the impl's abi, and then call initialize
-        minterBurner = ZkMinterBurnerImpl(minterBurnerProxy);
+        minterBurner = ZkMinterBurner(minterBurnerProxy);
         minterBurner.initialize(
             owner,
             admin,
@@ -99,7 +93,7 @@ library LibDeployInit {
         );
 
         // get a reference to the proxy, with the impl's abi, and then call initialize
-        nativeConverter = NativeConverterImpl(nativeConverterProxy);
+        nativeConverter = NativeConverter(nativeConverterProxy);
         nativeConverter.initialize(
             owner,
             admin,

--- a/src/L1Escrow.sol
+++ b/src/L1Escrow.sol
@@ -12,7 +12,7 @@ import {LibPermit} from "./helpers/LibPermit.sol";
 
 // This contract will receive USDC from users on L1 and trigger BridgeMinter on the zkEVM via LxLy.
 // This contract will hold all of the backing for USDC on zkEVM.
-contract L1EscrowImpl is IBridgeMessageReceiver, CommonAdminOwner {
+contract L1Escrow is IBridgeMessageReceiver, CommonAdminOwner {
     using SafeERC20Upgradeable for IUSDC;
 
     event Deposit(address indexed from, address indexed to, uint256 amount);

--- a/src/NativeConverter.sol
+++ b/src/NativeConverter.sol
@@ -14,7 +14,7 @@ import {LibPermit} from "./helpers/LibPermit.sol";
 // This contract will also have a permissionless publicly callable function called “migrate” which when called will
 // withdraw all BridgedWrappedUSDC to L1 via the LXLY bridge. The beneficiary address will be the L1Escrow,
 // thus migrating the supply and settling the balance.
-contract NativeConverterImpl is CommonAdminOwner {
+contract NativeConverter is CommonAdminOwner {
     using SafeERC20Upgradeable for IUSDC;
 
     event Convert(address indexed from, address indexed to, uint256 amount);

--- a/src/ZkMinterBurner.sol
+++ b/src/ZkMinterBurner.sol
@@ -18,7 +18,7 @@ import {LibPermit} from "./helpers/LibPermit.sol";
 // This contract will send messages to LXLY bridge on zkEVM,
 // it will hold the burner role giving it the ability to burn USDC.e based on instructions from LXLY,
 // triggering a release of assets on L1Escrow.
-contract ZkMinterBurnerImpl is IBridgeMessageReceiver, CommonAdminOwner {
+contract ZkMinterBurner is IBridgeMessageReceiver, CommonAdminOwner {
     using SafeERC20Upgradeable for IUSDC;
 
     event Withdraw(address indexed from, address indexed to, uint256 amount);

--- a/test/Base.sol
+++ b/test/Base.sol
@@ -8,11 +8,11 @@ import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {LibDeployInit} from "../scripts/DeployInitHelpers.sol";
 import "../src/mocks/MockBridge.sol";
 import "../src/L1EscrowProxy.sol";
-import "../src/L1EscrowImpl.sol";
+import "../src/L1Escrow.sol";
 import "../src/NativeConverterProxy.sol";
-import "../src/NativeConverterImpl.sol";
+import "../src/NativeConverter.sol";
 import "../src/ZkMinterBurnerProxy.sol";
-import "../src/ZkMinterBurnerImpl.sol";
+import "../src/ZkMinterBurner.sol";
 
 library Events {
     /* ================= EVENTS ================= */
@@ -28,13 +28,13 @@ library Events {
         uint32 depositCount
     );
 
-    // copy of NativeConverterImpl.Convert
+    // copy of NativeConverter.Convert
     event Convert(address indexed from, address indexed to, uint256 amount);
 
-    // copy of L1EscrowImpl.Deposit
+    // copy of L1Escrow.Deposit
     event Deposit(address indexed from, address indexed to, uint256 amount);
 
-    // copy of NativeConverterImpl.Migrate
+    // copy of NativeConverter.Migrate
     event Migrate(uint256 amount);
 
     // copy of ZkMinterBurner.Withdraw
@@ -73,11 +73,11 @@ contract Base is Test {
     IERC20 internal _erc20L2Wusdc;
 
     // L1 contracts
-    L1EscrowImpl internal _l1Escrow;
+    L1Escrow internal _l1Escrow;
 
     // L2 contracts
-    ZkMinterBurnerImpl internal _minterBurner;
-    NativeConverterImpl internal _nativeConverter;
+    ZkMinterBurner internal _minterBurner;
+    NativeConverter internal _nativeConverter;
 
     /* ================= SETUP ================= */
     function setUp() public virtual {

--- a/test/integration/AdminOperationsFlows.t.sol
+++ b/test/integration/AdminOperationsFlows.t.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.17;
 
 import {Base} from "../Base.sol";
-import "../../src/L1EscrowImpl.sol";
-import "../../src/NativeConverterImpl.sol";
-import "../../src/ZkMinterBurnerImpl.sol";
+import "../../src/L1Escrow.sol";
+import "../../src/NativeConverter.sol";
+import "../../src/ZkMinterBurner.sol";
 
 contract AdminAndOwnerOperationsFlows is Base {
     event AdminChanged(address previousAdmin, address newAdmin);
@@ -16,7 +16,7 @@ contract AdminAndOwnerOperationsFlows is Base {
         vm.selectFork(_l1Fork);
         vm.startPrank(_admin);
 
-        L1EscrowImpl newImpl = new L1EscrowImpl();
+        L1Escrow newImpl = new L1Escrow();
         address newImplAddr = address(newImpl);
 
         vm.expectEmit(address(_l1Escrow));
@@ -28,7 +28,7 @@ contract AdminAndOwnerOperationsFlows is Base {
         vm.selectFork(_l2Fork);
         vm.startPrank(_admin);
 
-        ZkMinterBurnerImpl newImpl = new ZkMinterBurnerImpl();
+        ZkMinterBurner newImpl = new ZkMinterBurner();
         address newImplAddr = address(newImpl);
 
         vm.expectEmit(address(_minterBurner));
@@ -40,7 +40,7 @@ contract AdminAndOwnerOperationsFlows is Base {
         vm.selectFork(_l2Fork);
         vm.startPrank(_admin);
 
-        NativeConverterImpl newImpl = new NativeConverterImpl();
+        NativeConverter newImpl = new NativeConverter();
         address newImplAddr = address(newImpl);
 
         vm.expectEmit(address(_nativeConverter));
@@ -54,7 +54,7 @@ contract AdminAndOwnerOperationsFlows is Base {
         vm.selectFork(_l1Fork);
         vm.startPrank(_alice);
 
-        L1EscrowImpl newImpl = new L1EscrowImpl();
+        L1Escrow newImpl = new L1Escrow();
         address newImplAddr = address(newImpl);
 
         vm.expectRevert("NOT_ADMIN");
@@ -65,7 +65,7 @@ contract AdminAndOwnerOperationsFlows is Base {
         vm.selectFork(_l2Fork);
         vm.startPrank(_alice);
 
-        ZkMinterBurnerImpl newImpl = new ZkMinterBurnerImpl();
+        ZkMinterBurner newImpl = new ZkMinterBurner();
         address newImplAddr = address(newImpl);
 
         vm.expectRevert("NOT_ADMIN");
@@ -76,7 +76,7 @@ contract AdminAndOwnerOperationsFlows is Base {
         vm.selectFork(_l2Fork);
         vm.startPrank(_alice);
 
-        NativeConverterImpl newImpl = new NativeConverterImpl();
+        NativeConverter newImpl = new NativeConverter();
         address newImplAddr = address(newImpl);
 
         vm.expectRevert("NOT_ADMIN");

--- a/test/invariant/LxLyHandler.sol
+++ b/test/invariant/LxLyHandler.sol
@@ -10,9 +10,9 @@ import {DSTest} from "lib/forge-std/src/Test.sol";
 
 import {Events} from "../Base.sol";
 import "../../src/mocks/MockBridge.sol";
-import "../../src/L1EscrowImpl.sol";
-import "../../src/ZkMinterBurnerImpl.sol";
-import "../../src/NativeConverterImpl.sol";
+import "../../src/L1Escrow.sol";
+import "../../src/ZkMinterBurner.sol";
+import "../../src/NativeConverter.sol";
 
 enum Operation {
     NOOP,
@@ -150,9 +150,9 @@ contract LxLyHandler is CommonBase, StdCheats, StdUtils, DSTest {
     IERC20 internal _erc20L1Usdc;
     IERC20 internal _erc20L2Usdc;
     IERC20 internal _erc20L2Wusdc;
-    L1EscrowImpl internal _l1Escrow;
-    NativeConverterImpl internal _nativeConverter;
-    ZkMinterBurnerImpl internal _minterBurner;
+    L1Escrow internal _l1Escrow;
+    NativeConverter internal _nativeConverter;
+    ZkMinterBurner internal _minterBurner;
 
     modifier useActor(uint256 actorIndexSeed) {
         currentActor = _actors[bound(actorIndexSeed, 0, _actors.length - 1)];
@@ -186,9 +186,9 @@ contract LxLyHandler is CommonBase, StdCheats, StdUtils, DSTest {
 
     function init(
         HandlerState state,
-        L1EscrowImpl l1Escrow,
-        NativeConverterImpl nativeConverter,
-        ZkMinterBurnerImpl minterBurner
+        L1Escrow l1Escrow,
+        NativeConverter nativeConverter,
+        ZkMinterBurner minterBurner
     ) external {
         _state = state;
         _l1Escrow = l1Escrow;


### PR DESCRIPTION
Remove these so that the name we call the contracts aligns with their true filename to improve readability